### PR TITLE
Allow default values

### DIFF
--- a/lib/interactor/initializer.rb
+++ b/lib/interactor/initializer.rb
@@ -13,14 +13,14 @@ module Interactor
     module ClassMethods
       module_function
 
-      def initialize_with(*attributes)
-        Interactor::Initializer::Initialize.for(self, attributes)
-        Interactor::Initializer::AttrReaders.for(self, attributes)
+      def initialize_with(*attributes, **defaults)
+        Interactor::Initializer::Initialize.for(self, attributes, defaults)
+        Interactor::Initializer::AttrReaders.for(self, attributes, defaults)
       end
 
-      def initialize_with_keyword_params(*attributes)
-        Interactor::Initializer::Initialize.for(self, attributes, keyword_params: true)
-        Interactor::Initializer::AttrReaders.for(self, attributes)
+      def initialize_with_keyword_params(*attributes, **defaults)
+        Interactor::Initializer::Initialize.for(self, attributes, defaults, keyword_params: true)
+        Interactor::Initializer::AttrReaders.for(self, attributes, defaults)
       end
     end
   end

--- a/lib/interactor/initializer/attr_readers.rb
+++ b/lib/interactor/initializer/attr_readers.rb
@@ -1,7 +1,7 @@
 class Interactor::Initializer::AttrReaders
-  def self.for(target_class, attributes)
+  def self.for(target_class, attributes, defaults)
     target_class.class_eval do
-      attributes.each do |attribute|
+      (attributes + defaults.keys).each do |attribute|
         attr_reader(attribute)
         protected(attribute)
       end

--- a/lib/interactor/initializer/initialize.rb
+++ b/lib/interactor/initializer/initialize.rb
@@ -3,33 +3,57 @@ class Interactor::Initializer::Initialize
     new(*args).run
   end
 
-  attr_reader :target_class, :attributes, :keyword_params
+  attr_reader :target_class, :attributes, :defaults, :keyword_params
 
-  def initialize(target_class, attributes, keyword_params: false)
+  def initialize(target_class, attributes, defaults, keyword_params: false)
     @target_class = target_class
     @attributes = attributes
+    @defaults = defaults
     @keyword_params = keyword_params
   end
 
   def run
-    target_class.class_eval <<-RUBY
-      def initialize(#{initializer_signature(attributes)})
-        #{attr_assignments(attributes)}
-      end
-    RUBY
+    define_initializer
+    define_defaults_initializer
   end
 
   private
 
-  def initializer_signature(attributes)
-    return attributes.join(', ') unless keyword_params
-
-    attributes.map { |attribute| "#{attribute}:" }.join(', ')
+  def define_initializer
+    target_class.class_eval <<-RUBY
+      def initialize(#{initializer_signature})
+        #{attr_assignments}
+        initialize_defaults
+      end
+    RUBY
   end
 
-  def attr_assignments(attributes)
-    attributes.inject('') do |assignments, attribute|
-      "#{assignments}@#{attribute} = #{attribute};"
+  def define_defaults_initializer
+    target_class.class_exec(defaults) do |defaults|
+      define_method :initialize_defaults do
+        defaults.keys.each do |name|
+          instance_variable_set("@#{name}", defaults[name]) unless instance_variable_get("@#{name}")
+        end
+      end
     end
+  end
+
+  def initializer_signature
+    keyword_params ? keyword_signature : regular_signature
+  end
+
+  def keyword_signature
+    keyword_params = attributes.map { |attribute| "#{attribute}:" }
+    default_params = defaults.keys.map { |key| "#{key}: nil" }
+    (keyword_params + default_params).join(', ')
+  end
+
+  def regular_signature
+    default_attributes = defaults.keys.map { |key| "#{key} = nil" }
+    (attributes + default_attributes).join(', ')
+  end
+
+  def attr_assignments
+    (defaults.keys + attributes).map { |attribute| "@#{attribute} = #{attribute}" }.join(';')
   end
 end

--- a/lib/interactor/initializer/version.rb
+++ b/lib/interactor/initializer/version.rb
@@ -1,5 +1,5 @@
 module Interactor
   module Initializer
-    VERSION = '0.2.0'.freeze
+    VERSION = '0.3.0'.freeze
   end
 end

--- a/spec/initializer/attr_readers_spec.rb
+++ b/spec/initializer/attr_readers_spec.rb
@@ -1,13 +1,15 @@
 describe Interactor::Initializer::AttrReaders do
   describe '.for' do
-    subject { described_class.for(dummy_class, attributes) }
+    subject { described_class.for(dummy_class, attributes, defaults) }
     let(:dummy_class) { Class.new }
     let(:attributes) { [:test1, :test2] }
+    let(:defaults) { { test3: 3 } }
 
     it 'adds protected attr_reader' do
       subject
       expect(dummy_class.protected_method_defined?(:test1)).to be_truthy
       expect(dummy_class.protected_method_defined?(:test2)).to be_truthy
+      expect(dummy_class.protected_method_defined?(:test3)).to be_truthy
     end
   end
 end

--- a/spec/initializer/initialize_spec.rb
+++ b/spec/initializer/initialize_spec.rb
@@ -1,27 +1,81 @@
 describe Interactor::Initializer::Initialize do
   describe '.for' do
-    subject { described_class.for(dummy_class, attributes, keyword_params: keyword_params) }
-    let(:dummy_class) { Class.new }
-    let(:attributes) { [:test1, :test2] }
-    let(:keyword_params) { false }
+    let(:target_class) { Class.new }
+    let(:expected_values) { { test1: 1, test2: Class.new } }
 
     shared_examples 'object initializer' do
-      it 'adds object initializer' do
+      it 'assigns variables' do
         subject
-        expect(dummy_instance.instance_variable_get(:@test1)).to eq 1
-        expect(dummy_instance.instance_variable_get(:@test2)).to eq 2
+
+        expected_values.each do |name, value|
+          expect(interactor.instance_variable_get("@#{name}")).to eq(value)
+        end
       end
     end
 
-    it_behaves_like 'object initializer' do
-      let(:dummy_instance) { dummy_class.new(1, 2) }
+    context 'when regular params' do
+      subject { described_class.for(target_class, attributes, defaults) }
+
+      it_behaves_like 'object initializer' do
+        let(:interactor) { target_class.new(expected_values[:test1], expected_values[:test2]) }
+        let(:attributes) { [:test1, :test2] }
+        let(:defaults) { {} }
+      end
+
+      context 'with default values' do
+        it_behaves_like 'object initializer' do
+          let(:interactor) { target_class.new(expected_values[:test1]) }
+          let(:attributes) { [:test1] }
+          let(:defaults) { { test2: expected_values[:test2] } }
+        end
+
+        it_behaves_like 'object initializer' do
+          let(:interactor) { target_class.new(expected_values[:test1], expected_values[:test2]) }
+          let(:attributes) { [:test1] }
+          let(:defaults) { { test2: 'default' } }
+        end
+      end
+
+      context 'when default values only' do
+        it_behaves_like 'object initializer' do
+          let(:interactor) { target_class.new }
+          let(:attributes) { [] }
+          let(:defaults) { expected_values }
+        end
+      end
     end
 
     context 'when keyword params' do
-      let(:keyword_params) { true }
+      subject { described_class.for(target_class, attributes, defaults, keyword_params: true) }
 
       it_behaves_like 'object initializer' do
-        let(:dummy_instance) { dummy_class.new(test1: 1, test2: 2) }
+        let(:interactor) { target_class.new(expected_values) }
+        let(:attributes) { [:test1, :test2] }
+        let(:defaults) { {} }
+      end
+
+      context 'with default values' do
+        it_behaves_like 'object initializer' do
+          let(:interactor) { target_class.new(test1: expected_values[:test1]) }
+          let(:attributes) { [:test1] }
+          let(:defaults) { { test2: expected_values[:test2] } }
+        end
+
+        it_behaves_like 'object initializer' do
+          let(:interactor) do
+            target_class.new(test1: expected_values[:test1], test2: expected_values[:test2])
+          end
+          let(:attributes) { [:test1] }
+          let(:defaults) { { test2: 'default' } }
+        end
+      end
+
+      context 'with default values only' do
+        it_behaves_like 'object initializer' do
+          let(:interactor) { target_class.new }
+          let(:attributes) { [] }
+          let(:defaults) { expected_values }
+        end
       end
     end
   end


### PR DESCRIPTION
It is often useful to initialize an interactor with default values. This PR enables that. For example `initialize_with`can now be used like this: `initialize_with :user, errors: []`

@vinted/backend 