### PR TITLE
Add no param methods by default when including initializer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    interactor-initializer (1.0.1)
+    interactor-initializer (1.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/interactor-initializer.gemspec
+++ b/interactor-initializer.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'interactor/initializer/version'

--- a/lib/interactor/initializer.rb
+++ b/lib/interactor/initializer.rb
@@ -7,6 +7,9 @@ module Interactor
   module Initializer
     def self.included(target_class)
       target_class.extend ClassMethods
+
+      class_methods = Interactor::Initializer::Helper.methods_with_params
+      Interactor::Initializer::Helper.modify_class(target_class, '', [], class_methods)
     end
 
     module ClassMethods

--- a/lib/interactor/initializer/version.rb
+++ b/lib/interactor/initializer/version.rb
@@ -1,5 +1,5 @@
 module Interactor
   module Initializer
-    VERSION = '1.0.1'.freeze
+    VERSION = '1.1.0'.freeze
   end
 end

--- a/spec/interactor/initializer_spec.rb
+++ b/spec/interactor/initializer_spec.rb
@@ -106,4 +106,52 @@ describe Interactor::Initializer do
       end
     end
   end
+
+  context 'with bare inclusion' do
+    let(:interactor) do
+      Class.new do
+        include Interactor::Initializer
+
+        def run
+          :result
+        end
+      end
+    end
+
+    describe '.run' do
+      subject { interactor.run }
+
+      it { is_expected.to eq(:result) }
+    end
+
+    describe '.for' do
+      subject { interactor.for }
+
+      it { is_expected.to eq(:result) }
+    end
+
+    describe '.with' do
+      subject { interactor.with }
+
+      it { is_expected.to eq(:result) }
+    end
+
+    context 'when class is not including interactor initializer' do
+      let(:interactor) do
+        Class.new do
+          def run
+            :result
+          end
+        end
+      end
+
+      describe '.run' do
+        subject { interactor.run }
+
+        it 'cannot call interactor' do
+          expect { subject }.to raise_error(/undefined method/)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Because the consensus was that we want to use the interactor inclusion (`include Interactor::Initializer`) even for no parameter interactors the default methods need to be created. In case when later `initialize_with` is used to specify parameters it will be overridden.

@vinted/platform-backend 