### PR TITLE
Define Interactor arguments explicitly to improve testability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    interactor-initializer (1.1.1)
+    interactor-initializer (1.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    interactor-initializer (1.1.2)
+    interactor-initializer (1.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/interactor/initializer.rb
+++ b/lib/interactor/initializer.rb
@@ -17,14 +17,14 @@ module Interactor
 
       def initialize_with(*attributes)
         signature = attributes.join(', ')
-        class_methods = Interactor::Initializer::Helper.methods_with_params
+        class_methods = Interactor::Initializer::Helper.methods_with_params(attributes)
 
         Interactor::Initializer::Helper.modify_class(self, signature, attributes, class_methods)
       end
 
       def initialize_with_keyword_params(*attributes)
         signature = attributes.map { |attr| "#{attr}:" }.join(', ')
-        class_methods = Interactor::Initializer::Helper.methods_with_keywords
+        class_methods = Interactor::Initializer::Helper.methods_with_keywords(attributes)
 
         Interactor::Initializer::Helper.modify_class(self, signature, attributes, class_methods)
       end

--- a/lib/interactor/initializer.rb
+++ b/lib/interactor/initializer.rb
@@ -24,7 +24,7 @@ module Interactor
 
       def initialize_with_keyword_params(*attributes)
         signature = attributes.map { |attr| "#{attr}:" }.join(', ')
-        class_methods = Interactor::Initializer::Helper.methods_with_keywords(attributes)
+        class_methods = Interactor::Initializer::Helper.methods_with_keywords
 
         Interactor::Initializer::Helper.modify_class(self, signature, attributes, class_methods)
       end

--- a/lib/interactor/initializer/helper.rb
+++ b/lib/interactor/initializer/helper.rb
@@ -24,34 +24,39 @@ class Interactor::Initializer::Helper
     end
   end
 
-  def self.methods_with_params
+  def self.methods_with_params(params = [])
+    params_signature = params.join(',')
+
     <<-RUBY
-      def self.for(*args)
-        new(*args).run
+      def self.for(#{params_signature})
+        new(#{params_signature}).run
       end
 
-      def self.run(*args)
-        new(*args).run
+      def self.run(#{params_signature})
+        new(#{params_signature}).run
       end
 
-      def self.with(*args)
-        new(*args).run
+      def self.with(#{params_signature})
+        new(#{params_signature}).run
       end
     RUBY
   end
 
-  def self.methods_with_keywords
+  def self.methods_with_keywords(attributes)
+    method_params = attributes.map { |attr| "#{attr}:" }.join(', ')
+    initializer_params = attributes.map { |attr| "#{attr}: #{attr}" }.join(', ')
+
     <<-RUBY
-      def self.for(args)
-        new(**args).run
+      def self.for(#{method_params})
+        new(#{initializer_params}).run
       end
 
-      def self.run(args)
-        new(**args).run
+      def self.run(#{method_params})
+        new(#{initializer_params}).run
       end
 
-      def self.with(args)
-        new(**args).run
+      def self.with(#{method_params})
+        new(#{initializer_params}).run
       end
     RUBY
   end

--- a/lib/interactor/initializer/helper.rb
+++ b/lib/interactor/initializer/helper.rb
@@ -24,39 +24,36 @@ class Interactor::Initializer::Helper
     end
   end
 
-  def self.methods_with_params(params = [])
-    params_signature = params.join(',')
+  def self.methods_with_params(attributes = [])
+    signature = attributes.join(', ')
 
     <<-RUBY
-      def self.for(#{params_signature})
-        new(#{params_signature}).run
+      def self.for(#{signature})
+        new(#{signature}).run
       end
 
-      def self.run(#{params_signature})
-        new(#{params_signature}).run
+      def self.run(#{signature})
+        new(#{signature}).run
       end
 
-      def self.with(#{params_signature})
-        new(#{params_signature}).run
+      def self.with(#{signature})
+        new(#{signature}).run
       end
     RUBY
   end
 
-  def self.methods_with_keywords(attributes)
-    method_params = attributes.map { |attr| "#{attr}:" }.join(', ')
-    initializer_params = attributes.map { |attr| "#{attr}: #{attr}" }.join(', ')
-
+  def self.methods_with_keywords
     <<-RUBY
-      def self.for(#{method_params})
-        new(#{initializer_params}).run
+      def self.for(args)
+        new(**args).run
       end
 
-      def self.run(#{method_params})
-        new(#{initializer_params}).run
+      def self.run(args)
+        new(**args).run
       end
 
-      def self.with(#{method_params})
-        new(#{initializer_params}).run
+      def self.with(args)
+        new(**args).run
       end
     RUBY
   end

--- a/lib/interactor/initializer/version.rb
+++ b/lib/interactor/initializer/version.rb
@@ -1,5 +1,5 @@
 module Interactor
   module Initializer
-    VERSION = '1.1.2'.freeze
+    VERSION = '1.2.0'.freeze
   end
 end

--- a/lib/interactor/initializer/version.rb
+++ b/lib/interactor/initializer/version.rb
@@ -1,5 +1,5 @@
 module Interactor
   module Initializer
-    VERSION = '1.1.1'.freeze
+    VERSION = '1.1.2'.freeze
   end
 end

--- a/spec/interactor/initializer_spec.rb
+++ b/spec/interactor/initializer_spec.rb
@@ -68,19 +68,19 @@ describe Interactor::Initializer do
     end
 
     describe '.for' do
-      subject { interactor.for(params) }
+      subject { interactor.for(**params) }
 
       it { is_expected.to eq(:result) }
     end
 
     describe '.with' do
-      subject { interactor.with(params) }
+      subject { interactor.with(**params) }
 
       it { is_expected.to eq(:result) }
     end
 
     describe '.run' do
-      subject { interactor.run(params) }
+      subject { interactor.run(**params) }
 
       it { is_expected.to eq(:result) }
     end
@@ -95,7 +95,7 @@ describe Interactor::Initializer do
     end
 
     context 'when incorrect keywords' do
-      subject { interactor.for(params) }
+      subject { interactor.for(**params) }
 
       let(:params) do
         { arg1: 'value2', arg4: 'value2' }

--- a/spec/interactor/initializer_spec.rb
+++ b/spec/interactor/initializer_spec.rb
@@ -68,19 +68,19 @@ describe Interactor::Initializer do
     end
 
     describe '.for' do
-      subject { interactor.for(**params) }
+      subject { interactor.for(params) }
 
       it { is_expected.to eq(:result) }
     end
 
     describe '.with' do
-      subject { interactor.with(**params) }
+      subject { interactor.with(params) }
 
       it { is_expected.to eq(:result) }
     end
 
     describe '.run' do
-      subject { interactor.run(**params) }
+      subject { interactor.run(params) }
 
       it { is_expected.to eq(:result) }
     end
@@ -95,7 +95,7 @@ describe Interactor::Initializer do
     end
 
     context 'when incorrect keywords' do
-      subject { interactor.for(**params) }
+      subject { interactor.for(params) }
 
       let(:params) do
         { arg1: 'value2', arg4: 'value2' }


### PR DESCRIPTION
**Problem**
Currently stubbing interactor calls is a risky activity. If you add an additional attribute to the `initialize_with` RSpec won't notice anything wrong from the call site if the interactor call is stubbed. I've seen this break production functionality multiple times, including for me. Example: https://github.com/vinted/core/pull/75015
 
**Solution**
Define methods in a less dynamic way so RSpec can see that the interactor call is stubbed with wrong argument count. 

Example: 
<img width="682" alt="Screenshot 2023-05-23 at 11 49 58" src="https://github.com/vinted/interactor-initializer/assets/542213/8e8dfd24-83d1-4c06-b432-80e59f48a4ff">

WDYT? I could work on improving the PR code quality if it's something we could use.

@vinted/platform-backend 