### PR TITLE
Define Interactor keyword arguments explicitly to improve testability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    interactor-initializer (1.2.0)
+    interactor-initializer (2.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/interactor/initializer.rb
+++ b/lib/interactor/initializer.rb
@@ -24,7 +24,7 @@ module Interactor
 
       def initialize_with_keyword_params(*attributes)
         signature = attributes.map { |attr| "#{attr}:" }.join(', ')
-        class_methods = Interactor::Initializer::Helper.methods_with_keywords
+        class_methods = Interactor::Initializer::Helper.methods_with_keywords(attributes)
 
         Interactor::Initializer::Helper.modify_class(self, signature, attributes, class_methods)
       end

--- a/lib/interactor/initializer/helper.rb
+++ b/lib/interactor/initializer/helper.rb
@@ -26,34 +26,38 @@ class Interactor::Initializer::Helper
 
   def self.methods_with_params(attributes = [])
     signature = attributes.join(', ')
+    initializer_params = signature
 
     <<-RUBY
       def self.for(#{signature})
-        new(#{signature}).run
+        new(#{initializer_params}).run
       end
 
       def self.run(#{signature})
-        new(#{signature}).run
+        new(#{initializer_params}).run
       end
 
       def self.with(#{signature})
-        new(#{signature}).run
+        new(#{initializer_params}).run
       end
     RUBY
   end
 
-  def self.methods_with_keywords
+  def self.methods_with_keywords(attributes)
+    signature = attributes.map { |attr| "#{attr}:" }.join(', ')
+    initializer_params = attributes.map { |attr| "#{attr}: #{attr}" }.join(', ')
+
     <<-RUBY
-      def self.for(args)
-        new(**args).run
+      def self.for(#{signature})
+        new(#{initializer_params}).run
       end
 
-      def self.run(args)
-        new(**args).run
+      def self.run(#{signature})
+        new(#{initializer_params}).run
       end
 
-      def self.with(args)
-        new(**args).run
+      def self.with(#{signature})
+        new(#{initializer_params}).run
       end
     RUBY
   end

--- a/lib/interactor/initializer/version.rb
+++ b/lib/interactor/initializer/version.rb
@@ -1,5 +1,5 @@
 module Interactor
   module Initializer
-    VERSION = '1.2.0'.freeze
+    VERSION = '2.0.0'.freeze
   end
 end

--- a/spec/interactor/initializer_spec.rb
+++ b/spec/interactor/initializer_spec.rb
@@ -68,19 +68,19 @@ describe Interactor::Initializer do
     end
 
     describe '.for' do
-      subject { interactor.for(params) }
+      subject { interactor.for(**params) }
 
       it { is_expected.to eq(:result) }
     end
 
     describe '.with' do
-      subject { interactor.with(params) }
+      subject { interactor.with(**params) }
 
       it { is_expected.to eq(:result) }
     end
 
     describe '.run' do
-      subject { interactor.run(params) }
+      subject { interactor.run(**params) }
 
       it { is_expected.to eq(:result) }
     end
@@ -95,7 +95,7 @@ describe Interactor::Initializer do
     end
 
     context 'when incorrect keywords' do
-      subject { interactor.for(params) }
+      subject { interactor.for(**params) }
 
       let(:params) do
         { arg1: 'value2', arg4: 'value2' }


### PR DESCRIPTION
Similar to https://github.com/vinted/interactor-initializer/pull/20

We could define keyword params methods similarly to plain params. This would improve the testability of those methods too.

Currently interactor methods accept a hash so this would be a breaking change. But there are not that many places where we explicitly pass in a hash in core. Here are the required changes: https://github.com/vinted/core/pull/75828

@vinted/platform-backend @oleg-vinted 